### PR TITLE
Add techsupport message to confirmation dialog

### DIFF
--- a/www/addevent.js
+++ b/www/addevent.js
@@ -133,7 +133,7 @@
                     var msg = isNew ?
                         'Thank you! A link with a URL to edit and manage the ' +
                             'event has been emailed to ' + postVars.email +
-                            '. You must click this link for the event to become visible.' :
+                            '. You must click this link for the event to become visible.  If you don\'t receive that email within 20 minutes, please contact bikecal@shift2bikes.org for help.' :
                         'Your event has been updated!';
 
                     if (returnVal.secret) {


### PR DESCRIPTION
Since we:

- had people report email failures
- can't easily debug those failures ourselves
- know that canvasdreams can't help debug email

...let's give folks a way to report problems other than the shift list or contact page.

PS:  I added myself to bikecal@shift2bikes.org.  Brian Scrivener, @OneHwang and myself are all listed.