### PR TITLE
Fixed wrap on event details and newsflash

### DIFF
--- a/www/index.css
+++ b/www/index.css
@@ -206,6 +206,7 @@ h3 {
 
 .eventDetails {
     color: rgb(64, 64, 64);
+    overflow-wrap: break-word;
 }
 
 .btn{

--- a/www/index.css
+++ b/www/index.css
@@ -154,6 +154,7 @@ h1 {
 
 .newsflash {
     color: rgb(255, 0, 255);
+    overflow-wrap: break-word;
 }
 
 h3 {


### PR DESCRIPTION
A cancelled event with a long word in the newsflash could force the page to be widen than necessary. Example: the URL in http://www.shift2bikes.org/fun/event-9490.