### PR TITLE
Fixed load more events request

### DIFF
--- a/www/main.js
+++ b/www/main.js
@@ -87,7 +87,7 @@ $(document).ready( function() {
     function viewEvents(){
         var startDate = new Date();
         var endDate = new Date(startDate);
-        endDate.setDate(startDate.getDate() + 9);
+        endDate.setDate(startDate.getDate() + 10);
         curPage = "viewEvents";
 
         container.empty()
@@ -107,7 +107,7 @@ $(document).ready( function() {
              $(document).off('click', '#load-more')
                   .on('click', '#load-more', function(e) {
                       startDate.setDate(startDate.getDate() + 10);
-                      endDate.setDate(startDate.getDate() + 9);
+                      endDate.setDate(endDate.getDate() + 10);
                       getEventHTML({
                           startdate: startDate,
                           enddate: endDate

--- a/www/main.js
+++ b/www/main.js
@@ -85,18 +85,22 @@ $(document).ready( function() {
     }
 
     function viewEvents(){
-        var startDate = new Date();
-        var endDate = new Date(startDate);
-        endDate.setDate(startDate.getDate() + 10);
         curPage = "viewEvents";
+
+        var days = 10;
+        function daysAfter(d) {
+            return new Date ((new Date(d)).setDate(d.getDate() + days));
+        }
+        var thisStart = new Date();
+        var nextStart = daysAfter(thisStart);
 
         container.empty()
              .append($('#scrollToTop').html())
              .append($('#ride-list-heading').html());
 
         getEventHTML({
-            startdate: startDate,
-            enddate: endDate
+            startdate: thisStart,
+            enddate: nextStart
         }, function (eventHTML) {
             if (curPage !== "viewEvents") {
                 return;
@@ -106,11 +110,11 @@ $(document).ready( function() {
              checkAnchors();
              $(document).off('click', '#load-more')
                   .on('click', '#load-more', function(e) {
-                      startDate.setDate(startDate.getDate() + 10);
-                      endDate.setDate(endDate.getDate() + 10);
+                      thisStart = nextStart;
+                      nextStart = daysAfter(thisStart);
                       getEventHTML({
-                          startdate: startDate,
-                          enddate: endDate
+                          startdate: thisStart,
+                          enddate: nextStart
                       }, function(eventHTML) {
                           $('#load-more').before(eventHTML);
                           checkAnchors();


### PR DESCRIPTION
`enddate` was incrementing from the `startdate` instead of `enddate`. That made the end date before the start date, thus the request returned no events.