### PR TITLE
Navbar style cleanup

### DIFF
--- a/www/index.css
+++ b/www/index.css
@@ -21,10 +21,19 @@ nav.navbar {
 .navbar-default {
     background-color: #f90;
     background-image: none;
+    border: 1px solid transparent;
+    border-top-left-radius: 0px;
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 4px;
+    border-bottom-left-radius: 4px;
 }
 
 .navbar-default .navbar-brand {
     color: #663300;
+}
+
+.navbar-default .navbar-collapse {
+    border: none;
 }
 
 .navbar-default svg.logo {
@@ -52,6 +61,7 @@ nav.navbar {
     display:inline-block;
     color: #630 !important;
     font-weight: bold;
+    text-shadow: none;
 }
 
 main a, button {


### PR DESCRIPTION
I realize the navbar styles will probably be irrelevant once the calendar gets dropped into the new site. But that hairline grey border that showed up on mobile when you expanded the menu was bothering me, so I fixed it. (There's actually still a very faint orange line dividing the top bar from the expanded menu, but it's subtle. Given the expected lifespan for this, I'm OK with it.) 