### PR TITLE
Fixed add/event form horizontal scrolling

### DIFF
--- a/www/index.css
+++ b/www/index.css
@@ -361,6 +361,9 @@ a.expandDetails {
     width: 310px;
     background-color: #fff56f;
 }
+form#event-entry .date-select-container-style {
+    width: 280px;
+}
 .date-select-container-style.jump-to-date {
     float: right;
     clear: right;
@@ -509,7 +512,7 @@ button.more-events {
 }
 
 .panel {
-    min-width: 320px;
+    min-width: 310px;
 }
 
 .panel h2 {


### PR DESCRIPTION
On devices with small screens (anything 320px wide), the add/event edit form scrolled horizontally just a bit. Minor adjustments to component widths fixes this. 