### PR TITLE
Moved audience label from Event model to JS helper

### DIFF
--- a/app/models/Event.php
+++ b/app/models/Event.php
@@ -31,7 +31,6 @@ class Event extends fActiveRecord {
             'webname' => $this->getWebname(),
             'image' => $this->getImagePath(),
             'audience' => $this->getAudience(),
-            'audiencelabel' => $this->getAudienceLabel(),
             //'printevent' => $this->getPrintevent(),
             'tinytitle' => $this->getTinytitle(),
             'printdescr' => $this->getPrintdescr(),
@@ -175,22 +174,6 @@ class Event extends fActiveRecord {
         return "$IMAGEPATH/$new_name";
     }
 
-    private function getAudienceLabel() {
-        $old_label = $this->getAudience();
-        if ($old_label == null) {
-            return null;
-        }
-
-        if ($old_label === "A") {
-            return "21+ Only";
-        }
-        if ($old_label === "F") {
-            return "Family Friendly";
-        }
-
-        // no label needed for general (G)
-        return null;
-    }
 }
 
 fORM::mapClassToTable('Event', 'calevent');

--- a/www/index.html
+++ b/www/index.html
@@ -263,9 +263,9 @@
                             {{#cancelled}}<del>{{/cancelled}}
 
                             <p><time>{{displayStartTime}}</time></p>
-                            {{#audiencelabel}}
-                                <span class="audience-{{audience}}">{{audiencelabel}}</span>
-                            {{/audiencelabel}}
+                            {{#audienceLabel}}
+                                <span class="audience-{{audience}}">{{audienceLabel}}</span>
+                            {{/audienceLabel}}
 
                             {{#cancelled}}</del>{{/cancelled}}
                         </div>

--- a/www/js/helpers.js
+++ b/www/js/helpers.js
@@ -1,5 +1,20 @@
 (function($) {
 
+    $.fn.getAudienceLabel = function(audience) {
+         if (audience == null) {
+             return null;
+         }
+
+         if (audience == "A") {
+             return "21+ Only";
+         } else if (audience == "F") {
+             return "Family Friendly";
+         } else {
+           //no label needed for general (G) or any other value
+           return null;
+        }
+    };
+
     $.fn.getMapLink = function(address) {
         return 'http://maps.google.com/' +
             '?bounds=45.389771,-122.829208|45.659647,-122.404175&q=' +

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -33,6 +33,8 @@ $(document).ready( function() {
                   value.displayEndTime = container.formatTime(value.endtime);
                 }
 
+                value.audienceLabel = container.getAudienceLabel(value.audience);
+
                 value.mapLink = container.getMapLink(value.address);
                 if ('id' in options) {
                     value.expanded = true;


### PR DESCRIPTION
Adding a friendly `audienceLabel` was the right idea (#153), but the `Event` model was the wrong place. The Event model already carries the `audience` attribute (with A/F/G abbreviated value); `audienceLabel` was mostly redundant and only for the front-end display. This moves it into a JS helper function.