### PR TITLE
Fixed logo home link

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -59,7 +59,7 @@
 
     <nav class="navbar navbar-default">
         <div class="navbar-header">
-            <a class="navbar-brand" href="/">
+            <a class="navbar-brand" href="http://www.shift2bikes.org/">
                 <svg class="logo" role="img" aria-label="Shift" width="152" height="82">
                     <use xlink:href="#shift-logo" />
                 </svg>


### PR DESCRIPTION
Previously, pressing the Shift logo navigated to `/` which in the Fun cal context reloaded the calendar. Now it always redirects to the Shift home page via an absolute link. 

This also fixes issue #141, since you are no longer on the ride list view after pressing the logo.  