### PR TITLE
Updating to latest 2.x jQuery release

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" type="text/css" href="css/bootstrap-theme.min.css">
     <link rel="stylesheet" type="text/css" href="css/main.css">
     <script src="//cdnjs.cloudflare.com/ajax/libs/mustache.js/2.3.0/mustache.min.js"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
     <script src="js/bootstrap.min.js"></script>
     <script src="js/formdata.js"></script>
     <script src="js/mailcheck.min.js"></script>


### PR DESCRIPTION
The official jQuery site says, "The 1.x and 2.x branches no longer receive patches," so it'd be good to move to jQuery v3 eventually. But for now, this at least moves us up to the latest 2.x release. 