### PR TITLE
Implement backwards-compatible raw JSON parsing

### DIFF
--- a/www/delete_event.php
+++ b/www/delete_event.php
@@ -8,13 +8,10 @@ include(getcwd() . '/../app/init.php');
 
 function build_json_response() {
     if (!isset($_POST['json'])) {
-        return array(
-            'error' => array(
-                'message' => 'No JSON found'
-            )
-        );
+        $data = json_decode(file_get_contents('php://input'), true);
+    } else {
+        $data = json_decode($_POST['json'], true);
     }
-    $data = json_decode($_POST['json'], true);
     if (!$data) {
         return array(
             'error' => array(

--- a/www/manage_event.php
+++ b/www/manage_event.php
@@ -24,13 +24,11 @@ include(getcwd() . '/../app/init.php');
 
 function build_json_response() {
     if (!isset($_POST['json'])) {
-        return array(
-            'error' => array(
-                'message' => "No JSON found"
-            )
-        );
+        $data = json_decode(file_get_contents('php://input'), true);
+    } else {
+        $data = json_decode($_POST['json'], true);
     }
-    $data = json_decode($_POST['json'], true);
+
     if (!$data) {
         return array(
             'error' => array(


### PR DESCRIPTION
It's a lot prettier to read and write raw JSON requests. 

This change makes writing raw JSON POST requests an option for development, and the functionality can later be ported to the front end as well.