### PR TITLE
Backend cancel event

### DIFF
--- a/app/models/Event.php
+++ b/app/models/Event.php
@@ -121,22 +121,7 @@ class Event extends fActiveRecord {
     }
 
     public function addEventTime($dateStatus) {
-        $date = $dateStatus['date'];
-
-        if (isset($dateStatus['status'])) {
-            $status = $dateStatus['status'];
-        } else {
-            $status = 'A';
-        }
-        $newsflash = $dateStatus['newsflash'];
-
-        $eventTime = new EventTime();
-        $eventTime->setModified(time());
-        $eventTime->setId($this->getId());
-        $eventTime->setEventdate($date->format('Y-m-d'));
-        $eventTime->setEventstatus($status);
-        $eventTime->setNewsflash($newsflash);
-        $eventTime->store();
+        EventTime::createNewEventTime($this->getId(), $dateStatus);
     }
 
     private function getDates() {

--- a/app/models/Event.php
+++ b/app/models/Event.php
@@ -102,17 +102,8 @@ class Event extends fActiveRecord {
     public function updateExistingEventTimes($dateStatuses) {
         foreach ($this->buildEventTimes('id') as $eventTime) {
             // For all existing EventTimes in the db
-            $dateStatusId = $eventTime->getPkid();
-            if (!isset($dateStatuses[$dateStatusId])) {
-                // EventTime exists in db but not in request
-                // They didn't resubmit this existing date - delete it
-                // TODO: Think about making the deletion functionality its own API endpoint
-                $eventTime->delete();
-            } else {
-                // EventTime exists in request and in db
-                // Update the existing EventTime and remove it from the array of new EventTimes
-                $eventTime->updateStatus($dateStatuses[$dateStatusId]);
-            }
+            // Delete or update
+            $eventTime->matchToDateStatus($dateStatuses);
         }
 
         // Flourish is suck. I can't figure out the "right" way to do one-to-many cause docs are crap

--- a/app/models/Event.php
+++ b/app/models/Event.php
@@ -138,7 +138,7 @@ class Event extends fActiveRecord {
         $detailArray = $this->toArray($include_hidden);
         // add all times that exist, maybe none.
         //$detailArray["dates"] = $this->getDates(); // Return the actual dates, not the hacky string
-        $detailArray["dateStatuses"] = $this->getEventDateStatuses(); 
+        $detailArray["datestatuses"] = $this->getEventDateStatuses(); 
         // return potentially augmented array
         return $detailArray;
     }

--- a/app/models/EventTime.php
+++ b/app/models/EventTime.php
@@ -4,7 +4,7 @@ class EventTime extends fActiveRecord {
     public static function createNewEventTime($eventId, $dateStatus) {
         $date = $dateStatus['date'];
         $newsflash = $dateStatus['newsflash'];
-        $status = EventTime::checkStatusNotNull($dateStatus);
+        $status = $dateStatus['status'];
 
         $eventTime = new EventTime();
         $eventTime->setModified(time());
@@ -13,16 +13,6 @@ class EventTime extends fActiveRecord {
         $eventTime->setEventstatus($status);
         $eventTime->setNewsflash($newsflash);
         $eventTime->store();
-    }
-
-    // TODO: This functionality should probably be delegated to the database
-    // but I don't know how to alter the schema to add a default value
-    // for the status column
-    public static function checkStatusNotNull($dateStatus) {
-        if (isset($dateStatus['status'])) {
-            return $dateStatus['status'];
-        } 
-        return 'A';
     }
 
     public static function getByID($id) {
@@ -63,10 +53,9 @@ class EventTime extends fActiveRecord {
     }
 
     private function updateStatus($dateStatus) {
-        $status = EventTime::checkStatusNotNull($dateStatus['status']);
-        if ($this->getEventstatus() !== $status) {
+        if ($this->getEventstatus() !== $dateStatus['status']) {
             // EventTime status is different than the request, update EventTime db entry
-            $this->setEventstatus($status);
+            $this->setEventstatus($dateStatus['status']);
         }
         if ($this->getNewsflash() !== $dateStatus['newsflash']) {
             // EventTime newsflash is different than the request, update EventTime db entry

--- a/app/models/EventTime.php
+++ b/app/models/EventTime.php
@@ -1,6 +1,25 @@
 <?php
 
 class EventTime extends fActiveRecord {
+    public static function createNewEventTime($eventId, $dateStatus) {
+        $date = $dateStatus['date'];
+
+        if (isset($dateStatus['status'])) {
+            $status = $dateStatus['status'];
+        } else {
+            $status = 'A';
+        }
+        $newsflash = $dateStatus['newsflash'];
+
+        $eventTime = new EventTime();
+        $eventTime->setModified(time());
+        $eventTime->setId($eventId);
+        $eventTime->setEventdate($date->format('Y-m-d'));
+        $eventTime->setEventstatus($status);
+        $eventTime->setNewsflash($newsflash);
+        $eventTime->store();
+    }
+
     public static function getByID($id) {
         return fRecordSet::build(
             'EventTime', // class

--- a/www/manage_event.php
+++ b/www/manage_event.php
@@ -133,7 +133,7 @@ function get_new_date_statuses($dateStatuses) {
     $newDateStatuses = array();
 
     foreach ($dateStatuses as $dateStatus) {
-        if ($dateStatus['id'] === null) {
+        if (empty($dateStatus['id'])) {
             $newDateStatuses []= $dateStatus;
         }
     }
@@ -145,7 +145,7 @@ function get_existing_date_statuses($dateStatuses) {
     $existingDateStatuses = array();
 
     foreach ($dateStatuses as $dateStatus) {
-        if ($dateStatus['id'] !== null) {
+        if (!empty($dateStatus['id'])) {
             $existingDateStatuses[$dateStatus['id']] = $dateStatus;
         }
     }

--- a/www/manage_event.php
+++ b/www/manage_event.php
@@ -22,21 +22,7 @@
 
 include(getcwd() . '/../app/init.php');
 
-function build_json_response() {
-    if (!isset($_POST['json'])) {
-        $data = json_decode(file_get_contents('php://input'), true);
-    } else {
-        $data = json_decode($_POST['json'], true);
-    }
-
-    if (!$data) {
-        return array(
-            'error' => array(
-                'message' => "JSON could not be decoded"
-            )
-        );
-    }
-
+function validate_json_request($data) {
     $_POST = $data; // fValidation inspects $_POST for field data
     $validator = new fValidation();
 
@@ -52,59 +38,10 @@ function build_json_response() {
         array('secret')
     );
 
-    $messages = $validator->validate(TRUE, TRUE);
-    if (!$data['read_comic']) {
-        $messages['read_comic'] = 'You must have read the Ride Leading Comic';
-    }
-    if ($messages) {
-        return array(
-            'error' => array(
-                'message' => 'There were errors in your fields',
-                'fields' => $messages
-            )
-        );
-    }
+    return $validator->validate(TRUE, TRUE);
+}
 
-    $inputDateStrings = get($data['dates'], array());
-    $validDates = array();
-    $invalidDates = array();
-    foreach ($inputDateStrings as $dateString) {
-        $date =  DateTime::createFromFormat('Y-m-d', $dateString);
-        if ($date) {
-            $validDates []= $date;
-        }
-        else {
-            $invalidDates []= $dateString;
-        }
-    }
-
-    if ($invalidDates) {
-        $messages['dates'] = "Invalid dates: " . implode(', ', $invalidDates);
-    }
-
-    if (count($validDates) === 1) {
-        $data['datestype'] = 'O';
-        $data['datestring'] = date_format($validDates[0], 'l, F j');
-    } else {
-        // not dealing with 'consecutive'
-        $data['datestype'] = 'S';
-        $data['datestring'] = 'Scattered days';
-    }
-
-    // Converts data to an event, loading the existing one if id is included in data
-    $event = Event::fromArray($data);
-
-    // Else
-    if ($event->exists() && !$event->secretValid($data['secret'])) {
-        return array(
-            'error' => array(
-                'message' => 'Invalid secret, use link from email'
-            )
-        );
-    }
-
-    $messages = $event->validate($return_messages=TRUE, $remove_column_names=TRUE);
-
+function upload_attached_file($event, $messages) {
     if (isset($_FILES['file'])) {
         $uploader = new fUpload();
         $uploader->setMIMETypes(
@@ -120,35 +57,172 @@ function build_json_response() {
         $uploader->setOptional();
         $file_message = $uploader->validate('file', TRUE);
         if ($file_message != null) {
-            $messages['file'] = $file_message;
+            $messages = array('file' => $file_message);
         }
         global $IMAGEDIR;
         $file = $uploader->move($IMAGEDIR, 'file');
         $event->setImage($file->getName());
     }
+    return $messages;
+}
+
+function field_error($messages) {
+    return array(
+        'error' => array(
+            'message' => 'There were errors in your fields',
+            'fields' => $messages
+        )
+    );
+}
+
+function text_error($message) {
+    return array(
+        'error' => array(
+            'message' => $message
+        )
+    );
+}
+
+function validate_date_statuses($data, $messages) {
+    $validDateStatuses = array();
+    $invalidDateStrings = array();
+
+    $inputDateStatuses = get($data['dateStatuses'], array());
+    foreach ($inputDateStatuses as $dateStatus) {
+        $dateString = $dateStatus['date'];
+        $date =  DateTime::createFromFormat('Y-m-d', $dateString);
+        if ($date) {
+            $dateStatus['date'] = $date;
+            $validDateStatuses[] = $dateStatus;
+        } else {
+            $invalidDateStrings []= $dateString;
+        }
+    }
+
+    if ($invalidDateStrings) {
+        $messages['dates'] = "Invalid dates: " . implode(', ', $invalidDateStrings);
+    }
+
+    $validatedDateStatuses = array(
+        'validDateStatuses' => $validDateStatuses,
+        'messages' => $messages
+    );
+
+    return $validatedDateStatuses;
+}
+
+function get_dates_type($validDateStatuses) {
+    if (count($validDateStatuses) === 1) {
+        return 'O';
+    } else {
+        // not dealing with 'consecutive'
+        return 'S';
+    }
+}
+
+function get_date_string($validDateStatuses) {
+    if (count($validDateStatuses) === 1) {
+        return date_format(end($validDateStatuses)['date'], 'l, F j');
+    } else {
+        // not dealing with 'consecutive'
+        return 'Scattered days';
+    }
+}
+
+function get_new_date_statuses($dateStatuses) {
+    $newDateStatuses = array();
+
+    foreach ($dateStatuses as $dateStatus) {
+        if ($dateStatus['id'] === null) {
+            $newDateStatuses []= $dateStatus;
+        }
+    }
+
+    return $newDateStatuses;
+}
+
+function get_existing_date_statuses($dateStatuses) {
+    $existingDateStatuses = array();
+
+    foreach ($dateStatuses as $dateStatus) {
+        if ($dateStatus['id'] !== null) {
+            $existingDateStatuses[$dateStatus['id']] = $dateStatus;
+        }
+    }
+
+    return $existingDateStatuses;
+}
+
+function create_new_event_times($event, $newDateStatuses){
+    foreach ($newDateStatuses as $dateStatus) {
+        $event->addEventTime($dateStatus);
+    }
+}
+
+function update_existing_event_times($event, $existingDateStatuses) {
+    $event->updateExistingEventTimes($existingDateStatuses);
+}
+
+function build_json_response() {
+    if (!isset($_POST['json'])) {
+        $data = json_decode(file_get_contents('php://input'), true);
+    } else {
+        $data = json_decode($_POST['json'], true);
+    }
+
+    if (!$data) {
+        return text_error("JSON could not be decoded");
+    }
+
+    $messages = validate_json_request($data);
+
+    if (!$data['read_comic']) {
+        $messages['read_comic'] = "You must have read the Ride Leading Comic";
+    }
 
     if ($messages) {
-        return array(
-            'error' => array(
-                'message' => 'There were errors in your fields',
-                'fields' => $messages
-            )
-        );
+        return field_error($messages);
+    }
+
+    // Converts data to an event, loading the existing one if id is included in data
+    $event = Event::fromArray($data);
+
+    // Else
+    if ($event->exists() && !$event->secretValid($data['secret'])) {
+        return text_error("Invalid secret, use link from email");
+    }
+
+    $messages = $event->validate($return_messages=TRUE, $remove_column_names=TRUE);
+    $messages = upload_attached_file($event, $messages);
+
+    $validatedDateStatuses = validate_date_statuses($data, $messages);
+    $validDateStatuses = $validatedDateStatuses['validDateStatuses'];
+    $messages = $validatedDateStatuses['messages'];
+
+    $data['datestype'] = get_dates_type($validDateStatuses);
+    $data['datestring'] = get_date_string($validDateStatuses);
+
+    $newDateStatuses = get_new_date_statuses($validDateStatuses);
+    $existingDateStatuses = get_existing_date_statuses($validDateStatuses);
+
+    if ($messages) {
+        return field_error($messages);
     }
 
     // if needs secret generate and email
     if (!$event->exists()) {
         $includeSecret = true;
-    }
-    else {
+    } else {
         $includeSecret = false;
     }
 
     // If there are validation errors this starts spewing html, so we validate before
     $event->store();
 
-    // Create/delete EventTimes to match the list of dates included
-    EventTime::matchEventTimesToDates($event, $validDates);
+    // The following operations must occur in the order: UPDATE -> CREATE NEW
+    // Otherwise the update function will delete the newly created EventTimes
+    update_existing_event_times($event, $existingDateStatuses);
+    create_new_event_times($event, $newDateStatuses);
 
     // Returns the created object
     $details = $event->toDetailArray(true);

--- a/www/manage_event.php
+++ b/www/manage_event.php
@@ -87,7 +87,7 @@ function validate_date_statuses($data, $messages) {
     $validDateStatuses = array();
     $invalidDateStrings = array();
 
-    $inputDateStatuses = get($data['dateStatuses'], array());
+    $inputDateStatuses = get($data['datestatuses'], array());
     foreach ($inputDateStatuses as $dateStatus) {
         $dateString = $dateStatus['date'];
         $date =  DateTime::createFromFormat('Y-m-d', $dateString);


### PR DESCRIPTION
This is a breaking API change. Rather than using the 'date' field
in the passed JSON object for setting and removing EventTimes, this
change uses a new field called 'dateStatuses', which is an array of
dateStatus objects of the following format:
```
{
    'id': <EventTime pkid || null>,
    'date': 'YYYY-MM-DD',
    'status': < 'C' || 'A' >,
    'newsflash': <Newsflash shown if status === 'C' || null>
}
```
The 'id' field should be null for a new EventTime, or the pkid for
existing EventTimes.

The 'date' field should be of the same format as the old date field:
'yyyy-mm-dd'.

The status should be 'A' for normal or 'C' for cancelled. It may be left
null for new events, in which case it will default to 'A'.

The newsflash should be populated with a message if status === 'C',
otherwise it may be populated with either a message or null.

To delete an existing EventTime, simply remove it's corresponding
dateStatus object from the dateStatuses field.

Important note: The function EventTime::matchEventTimesToDates has been split up and moved into the Event class, as addEventTime and updateExistingEventTimes. This seemed more natural due to the fact that EventTimes belong to Events, so the Event should be CRUDing them.

Also in this commit: refactoring manage_event.php to make it more
readable.