### PR TITLE
Make all functions in addevent.js less than one screen high and add a default audience

### DIFF
--- a/app/models/Event.php
+++ b/app/models/Event.php
@@ -85,7 +85,7 @@ class Event extends fActiveRecord {
         $event->setEventduration(get($input['eventduration'], 0));
         $event->setWeburl(get($input['weburl'], ''));
         $event->setWebname(get($input['webname'], ''));
-        $event->setAudience(get($input['audience'], ''));
+        $event->setAudience(get($input['audience'], 'G')); // default to 'G'eneral
         $event->setTinytitle(get($input['tinytitle'], ''));
         $event->setPrintdescr(get($input['printdescr'], ''));
         $event->setDates(get($input['datestring'], '')); // string field 'dates' needed for legacy admin calendar

--- a/www/js/addevent.js
+++ b/www/js/addevent.js
@@ -78,7 +78,7 @@
 
             $('#save-result').addClass('text-danger').text(err.message);
 
-            addFieldErrors();
+            addFieldErrors(err);
             expandErrorFields();
         });
     }
@@ -125,7 +125,7 @@
         $('#secret').val(returnVal.secret);
     }
 
-    function addFieldErrors() {
+    function addFieldErrors(err) {
         $.each(err.fields, function (fieldName, message) {
             var input = $('[name=' + fieldName + ']');
             var parent = input.closest('.form-group,.checkbox');
@@ -157,7 +157,7 @@
 
         shiftEvent.timeOptions = [];
         meridian = 'AM';
-        // TODO: There has to be a better way to do this
+        // TODO: Use moment here
         for ( h = 0; h < 24; h++ ) {
             for ( m = 0; m < 60; m += 15 ) {
                 if ( h > 11 ) {

--- a/www/js/addevent.js
+++ b/www/js/addevent.js
@@ -52,7 +52,11 @@
 
     function saveEvent(shiftEvent) {
         var isNew = !shiftEvent.id;
-        var opts = buildSaveEventRequest(shiftEvent, isNew)
+        var postVars = eventFromForm();
+        if (!isNew) {
+            postVars['id'] = shiftEvent.id;
+        }
+        var opts = buildSaveEventRequest(postVars)
 
         $.when($.ajax(opts)).done(function (returnVal) {
             var msg = isNew ?
@@ -83,17 +87,11 @@
         });
     }
 
-    function buildSaveEventRequest(shiftEvent, isNew) {
+    function buildSaveEventRequest(postVars) {
         $('.form-group').removeClass('has-error');
         $('[aria-invalid="true"]').attr('aria-invalid', false);
         $('.help-block').remove();
         $('#save-result').removeClass('text-danger').text('');
-
-        var postVars = eventFromForm();
-
-        if (!isNew) {
-            postVars['id'] = shiftEvent.id;
-        }
 
         var data = new FormData();
         $.each($('#image')[0].files, function (i, file) {


### PR DESCRIPTION
I went through `addevent.js` and broke it up into smaller functions as best I could. `populateEditForm` was particularly monolithic so it was the primary target for being broken into smaller pieces. 

I also noticed there was some minor "validation" happening via null checking area and audience, I added a default for audience on the backend, there was already one for area, so we should never be getting a null value except in the case of new events maybe. In any case I changed the display order of the audience array so it defaults to 'General' without null checking now.

This definitely isn't perfect, there is heavy mutation of the `shiftEvent` object happening in many of the functions, but it's necessary that we start somewhere with breaking stuff into more digestible pieces or this code base is going to be very hard for new developers to approach.  Additionally, once things start getting broken up more it will be easier to reason about which objects are really used across the whole file/multiple files and figure out ways to change how we are tackling the problems that are currently being solved with mutable globals. Totally open to criticism regarding how I approached it though.

Side Note: This may be in conflict with changes that @carrythebanner is working on - I'm not sure how heavily your changes have affected this file. If this is the case, we can wait to merge this one till after we have everything we want in for June wrapped up.