### PR TITLE
Indicate featured days in PP date picker

### DIFF
--- a/www/css/main.css
+++ b/www/css/main.css
@@ -427,6 +427,31 @@ button.jump-to-date[aria-expanded="true"] .icon.expand {
     transform: rotate(180deg); /* arrow pointing up */
 }
 
+#date-select-container-pedalpalooza .calendar-day.featured {
+    background-color: #FCFAF2;
+    border-left: 2px solid #FFDD66;
+    border-right: 2px solid #FFDD66;
+    font-weight: bold;
+    color: #630;
+    position: relative;
+}
+#date-select-container-pedalpalooza .calendar-day.featured span.featured-day-label {
+    font-size: 0.5em;
+    opacity: 0.5;
+    position: absolute;
+}
+#date-select-container-pedalpalooza .legend {
+    text-align: center;
+    margin: 0.5em;
+}
+#date-select-container-pedalpalooza .legend .example {
+    background-color: #FCFAF2;
+    border: 2px solid #FFDD66;
+    color: #630;
+    font-weight: bold;
+    padding: 0.5em;
+}
+
 #date-select {
     height: 130px;
 }
@@ -455,7 +480,7 @@ button.jump-to-date[aria-expanded="true"] .icon.expand {
 .calendar-day {
     border-top: 1px solid gray;
     padding: 3px;
-    color: gray;
+    color: #404040;
     line-height: 1.5em;
     text-align: center;
 }
@@ -466,40 +491,40 @@ button.jump-to-date[aria-expanded="true"] .icon.expand {
 }
 
 .calendar-day.today {
-    background-color: green;
+    background-color: lightgreen;
 }
 
 .calendar-day.selected {
-    background-color: red;
+    background-color: lightpink;
 }
 
 .calendar-month-title {
     position: relative;
     width: 30px;
-    color: #fff;
-    background-color: #f90;
+    color: #630;
+    background-color: #fd6;
     font-weight: bold;
 }
 
 .color-jan, .color-mar,
 .color-may, .color-jul,
 .color-sep, .color-nov {
-    background-color: #fc6;
+    background-color: #ffffff;
 }
 .color-jan-odd, .color-mar-odd,
 .color-may-odd, .color-jul-odd,
 .color-sep-odd, .color-nov-odd {
-    background-color: #fd6;
+    background-color: #f2f2f2;
 }
 .color-feb, .color-apr,
 .color-jun, .color-aug,
 .color-oct, .color-dec {
-    background-color: #fd6;
+    background-color: #ffffff;
 }
 .color-feb-odd, .color-apr-odd,
 .color-jun-odd, .color-aug-odd,
 .color-oct-odd, .color-dec-odd {
-    background-color: #fe9;
+    background-color: #f2f2f2;
 }
 
 .calendar-month-title span {
@@ -518,7 +543,7 @@ button.jump-to-date[aria-expanded="true"] .icon.expand {
     font-size: 0.9em;
     text-align: center;
     table-layout: fixed;
-    color: gray;
+    color: #404040;
 }
 #preview-edit-button {
     display: none;

--- a/www/css/main.css
+++ b/www/css/main.css
@@ -426,27 +426,24 @@ button.jump-to-date .icon.expand {
 button.jump-to-date[aria-expanded="true"] .icon.expand {
     transform: rotate(180deg); /* arrow pointing up */
 }
+#date-select-container-pedalpalooza {
+    border-collapse: separate !important;
+}
 
 #date-select-container-pedalpalooza .calendar-day.featured {
     background-color: #FCFAF2;
-    border-left: 2px solid #FFDD66;
-    border-right: 2px solid #FFDD66;
+    border: 3px solid #FFDD66;
     font-weight: bold;
     color: #630;
     position: relative;
 }
-#date-select-container-pedalpalooza .calendar-day.featured span.featured-day-label {
-    font-size: 0.5em;
-    opacity: 0.5;
-    position: absolute;
-}
 #date-select-container-pedalpalooza .legend {
     text-align: center;
-    margin: 0.5em;
+    margin: 0.75em;
 }
 #date-select-container-pedalpalooza .legend .example {
     background-color: #FCFAF2;
-    border: 2px solid #FFDD66;
+    border: 3px solid #FFDD66;
     color: #630;
     font-weight: bold;
     padding: 0.5em;

--- a/www/index.html
+++ b/www/index.html
@@ -197,17 +197,17 @@
                         <td class="calendar-day   color-jun"></td>
                         <td class="calendar-day   color-jun-odd"></td>
                         <td class="calendar-day   color-jun"></td>
-                        <td class="calendar-day   color-jun-odd featured" data-date="2018-06-01">1<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
+                        <td class="calendar-day   color-jun-odd featured" data-date="2018-06-01" aria-describedby="pp-featured-day-label">1</td>
                         <td class="calendar-day   color-jun" data-date="2018-06-02">2</td>
                     </tr>
                     <tr class="calendar-row">
                         <td class="calendar-day   color-jun" data-date="2018-06-03">3</td>
                         <td class="calendar-day   color-jun-odd" data-date="2018-06-04">4</td>
-                        <td class="calendar-day   color-jun featured" data-date='2018-06-05'>5<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
+                        <td class="calendar-day   color-jun featured" data-date='2018-06-05' aria-describedby="pp-featured-day-label">5</td>
                         <td class="calendar-day   color-jun-odd" data-date="2018-06-06">6</td>
                         <td class="calendar-day   color-jun" data-date="2018-06-07">7</td>
-                        <td class="calendar-day   color-jun-odd featured" data-date="2018-06-08">8<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
-                        <td class="calendar-day   color-jun featured" data-date="2018-06-09">9<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
+                        <td class="calendar-day   color-jun-odd featured" data-date="2018-06-08" aria-describedby="pp-featured-day-label">8</td>
+                        <td class="calendar-day   color-jun featured" data-date="2018-06-09" aria-describedby="pp-featured-day-label">9</td>
                     </tr>
                     <tr class="calendar-row">
                         <td class="calendar-day   color-jun" data-date="2018-06-10">10</td>
@@ -215,8 +215,8 @@
                         <td class="calendar-day   color-jun" data-date='2018-06-12'>12</td>
                         <td class="calendar-day   color-jun-odd" data-date="2018-06-13">13</td>
                         <td class="calendar-day   color-jun" data-date="2018-06-14">14</td>
-                        <td class="calendar-day   color-jun-odd featured" data-date="2018-06-15">15<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
-                        <td class="calendar-day   color-jun featured" data-date="2018-06-16">16<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
+                        <td class="calendar-day   color-jun-odd featured" data-date="2018-06-15" aria-describedby="pp-featured-day-label">15</td>
+                        <td class="calendar-day   color-jun featured" data-date="2018-06-16" aria-describedby="pp-featured-day-label">16</td>
                     </tr>
                     <tr class="calendar-row">
                     	<td rowspan="2" class="calendar-month-title">&nbsp;</td>
@@ -226,21 +226,21 @@
                         <td class="calendar-day   color-jun-odd" data-date="2018-06-20">20</td>
                         <td class="calendar-day   color-jun" data-date="2018-06-21">21</td>
                         <td class="calendar-day   color-jun-odd" data-date="2018-06-22">22</td>
-                        <td class="calendar-day   color-jun featured" data-date="2018-06-23">23<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
+                        <td class="calendar-day   color-jun featured" data-date="2018-06-23" aria-describedby="pp-featured-day-label">23</td>
                     </tr>
 
                     <tr class="calendar-row">
-                        <td class="calendar-day   color-jun featured" data-date="2018-06-24">24<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
+                        <td class="calendar-day   color-jun featured" data-date="2018-06-24" aria-describedby="pp-featured-day-label">24</td>
                         <td class="calendar-day   color-jun-odd" data-date="2018-06-25">25</td>
                         <td class="calendar-day   color-jun" data-date="2018-06-26">26</td>
-                        <td class="calendar-day   color-jun-odd featured" data-date="2018-06-27">27<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
+                        <td class="calendar-day   color-jun-odd featured" data-date="2018-06-27" aria-describedby="pp-featured-day-label">27</td>
                         <td class="calendar-day   color-jun" data-date="2018-06-28">28</td>
                         <td class="calendar-day   color-jun-odd" data-date="2018-06-29">29</td>
-                        <td class="calendar-day   color-jun featured" data-date="2018-06-30">30<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
+                        <td class="calendar-day   color-jun featured" data-date="2018-06-30" aria-describedby="pp-featured-day-label">30</td>
                     </tr>
                 </table>
             </div>
-            <p class="legend"><span class="example" aria-hidden="true">★</span> = <span id="pp-featured-day-label">day with featured event</a></p>
+            <p class="legend" aria-hidden="true"><span class="example">★</span> = <span id="pp-featured-day-label">day with featured event</span></p>
         </div>
     </script>
 

--- a/www/index.html
+++ b/www/index.html
@@ -152,10 +152,11 @@
                 <span>About Pedalpalooza</span>
             </button>
             <div id="pp-description">
-                <p>Pedalpalooza is a month of bikey fun. With dozens of different events, most organized by individuals, bikers of all persuasions are likely to find many events of interest. Nearly all events are free. </p>
+                <p>Pedalpalooza is a month of bikey fun. With hundreds of different events, most organized by individuals, bikers of all persuasions are likely to find many events of interest. Nearly all events are free. </p>
                 <p><a href="addEvent"><strong>Add your events for 2018 now!</strong></a> Seeking inspiration? View the <a href="pedalpaloozaArchive">Pedalpalooza archives</a> of past bicycle fun events. If you need help creating or editing an event, <a href="http://www.shift2bikes.org/contacts/index.php?eCon=CalCrew">contact the calendar crew</a>.</p>
-                <p> Visiting from out of town? We've started a <a href="http://www.shift2bikes.org/allbike.php#Visitor_Info">Visitor Info</a> page.</p>
-                <p> <a href="https://docs.shift2bikes.org/pages/pedalpalooza/">More info…</a> </p>
+                <p>Looking for an overview of the full month? Check out the <a href="http://shift2bikes.org/cal/viewpp2018.php">classic cal</a>.</p>
+                <p>Visiting from out of town? We've started a <a href="http://www.shift2bikes.org/allbike.php#Visitor_Info">Visitor Info</a> page.</p>
+                <p> <a href="https://docs.shift2bikes.org/pages/pedalpalooza/">More about Pedalpalooza…</a> </p>
                 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
                     <input type="hidden" name="cmd" value="_s-xclick">
                     <input type="hidden" name="hosted_button_id" value="YJYFXDPLSCW8U">
@@ -196,17 +197,17 @@
                         <td class="calendar-day   color-jun"></td>
                         <td class="calendar-day   color-jun-odd"></td>
                         <td class="calendar-day   color-jun"></td>
-                        <td class="calendar-day   color-jun-odd" data-date="2018-06-01">1</td>
+                        <td class="calendar-day   color-jun-odd featured" data-date="2018-06-01">1<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
                         <td class="calendar-day   color-jun" data-date="2018-06-02">2</td>
                     </tr>
                     <tr class="calendar-row">
                         <td class="calendar-day   color-jun" data-date="2018-06-03">3</td>
                         <td class="calendar-day   color-jun-odd" data-date="2018-06-04">4</td>
-                        <td class="calendar-day   color-jun" data-date='2018-06-05'>5</td>
+                        <td class="calendar-day   color-jun featured" data-date='2018-06-05'>5<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
                         <td class="calendar-day   color-jun-odd" data-date="2018-06-06">6</td>
                         <td class="calendar-day   color-jun" data-date="2018-06-07">7</td>
-                        <td class="calendar-day   color-jun-odd" data-date="2018-06-08">8</td>
-                        <td class="calendar-day   color-jun" data-date="2018-06-09">9</td>
+                        <td class="calendar-day   color-jun-odd featured" data-date="2018-06-08">8<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
+                        <td class="calendar-day   color-jun featured" data-date="2018-06-09">9<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
                     </tr>
                     <tr class="calendar-row">
                         <td class="calendar-day   color-jun" data-date="2018-06-10">10</td>
@@ -214,8 +215,8 @@
                         <td class="calendar-day   color-jun" data-date='2018-06-12'>12</td>
                         <td class="calendar-day   color-jun-odd" data-date="2018-06-13">13</td>
                         <td class="calendar-day   color-jun" data-date="2018-06-14">14</td>
-                        <td class="calendar-day   color-jun-odd" data-date="2018-06-15">15</td>
-                        <td class="calendar-day   color-jun" data-date="2018-06-16">16</td>
+                        <td class="calendar-day   color-jun-odd featured" data-date="2018-06-15">15<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
+                        <td class="calendar-day   color-jun featured" data-date="2018-06-16">16<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
                     </tr>
                     <tr class="calendar-row">
                     	<td rowspan="2" class="calendar-month-title">&nbsp;</td>
@@ -225,20 +226,21 @@
                         <td class="calendar-day   color-jun-odd" data-date="2018-06-20">20</td>
                         <td class="calendar-day   color-jun" data-date="2018-06-21">21</td>
                         <td class="calendar-day   color-jun-odd" data-date="2018-06-22">22</td>
-                        <td class="calendar-day   color-jun" data-date="2018-06-23">23</td>
+                        <td class="calendar-day   color-jun featured" data-date="2018-06-23">23<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
                     </tr>
 
                     <tr class="calendar-row">
-                        <td class="calendar-day   color-jun" data-date="2018-06-24">24</td>
+                        <td class="calendar-day   color-jun featured" data-date="2018-06-24">24<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
                         <td class="calendar-day   color-jun-odd" data-date="2018-06-25">25</td>
                         <td class="calendar-day   color-jun" data-date="2018-06-26">26</td>
-                        <td class="calendar-day   color-jun-odd" data-date="2018-06-27">27</td>
+                        <td class="calendar-day   color-jun-odd featured" data-date="2018-06-27">27<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
                         <td class="calendar-day   color-jun" data-date="2018-06-28">28</td>
                         <td class="calendar-day   color-jun-odd" data-date="2018-06-29">29</td>
-                        <td class="calendar-day   color-jun" data-date="2018-06-30">30</td>
+                        <td class="calendar-day   color-jun featured" data-date="2018-06-30">30<span class="featured-day-label" aria-labelledby="pp-featured-day-label">★</span></td>
                     </tr>
                 </table>
             </div>
+            <p class="legend"><span class="example" aria-hidden="true">★</span> = <span id="pp-featured-day-label">day with featured event</a></p>
         </div>
     </script>
 


### PR DESCRIPTION
Implements #219 — events with featured days are now displayed differently in the date picker on the Pedalpalooza page. I also rolled in some color contrast fixes, and a link to the classic cal in the PP about header (#220). 