### PR TITLE
Added About Pedalpalooza page

### DIFF
--- a/www/.htaccess
+++ b/www/.htaccess
@@ -12,4 +12,4 @@ RewriteRule ^event-([0-9]+)$ %{ENV:CWD}crawl.php?id=$1 [L]
 RewriteCond %{HTTP_USER_AGENT} (facebookexternalhit/[0-9]|Twitterbot|Pinterest|Google.*snippet)
 RewriteRule (^$|^pedalpalooza$|^index.html$) %{ENV:CWD}crawl.php [L]
 
-RewriteRule ^(event-[0-9]+|pedalpalooza|viewEvents|addEvent|editEvent-[0-9]+-[0-9a-f]+|aboutUs|pedalpaloozaArchive)$ %{ENV:CWD}index.html
+RewriteRule ^(event-[0-9]+|pedalpalooza|viewEvents|addEvent|editEvent-[0-9]+-[0-9a-f]+|aboutUs|pedalpaloozaArchive|aboutPedalpalooza)$ %{ENV:CWD}index.html

--- a/www/index.html
+++ b/www/index.html
@@ -156,7 +156,7 @@
                 <p><a href="addEvent"><strong>Add your events for 2018 now!</strong></a> Seeking inspiration? View the <a href="pedalpaloozaArchive">Pedalpalooza archives</a> of past bicycle fun events. If you need help creating or editing an event, <a href="http://www.shift2bikes.org/contacts/index.php?eCon=CalCrew">contact the calendar crew</a>.</p>
                 <p>Looking for an overview of the full month? Check out the <a href="http://shift2bikes.org/cal/viewpp2018.php">classic cal</a>.</p>
                 <p>Visiting from out of town? We've started a <a href="http://www.shift2bikes.org/allbike.php#Visitor_Info">Visitor Info</a> page.</p>
-                <p> <a href="https://docs.shift2bikes.org/pages/pedalpalooza/">More about Pedalpalooza…</a> </p>
+                <p> <a href="aboutPedalpalooza">More about Pedalpalooza…</a> </p>
                 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
                     <input type="hidden" name="cmd" value="_s-xclick">
                     <input type="hidden" name="hosted_button_id" value="YJYFXDPLSCW8U">
@@ -244,13 +244,40 @@
         </div>
     </script>
 
+    <script id="aboutPedalpalooza" type="text">
+        <div>
+            <h1>About Pedalpalooza</h1>
+
+			<div class="plain">
+
+                <p>Pedalpalooza is an annual festival in Metro Portland, Oregon. During the festival, there are hundreds of volunteer-organized free events open to the general public. Each year there are well over 10,000 participants in these events, which are almost entirely on bikes and free. There are some annual flagship rides which usually have over 1000 riders, and many first-time ever rides - some of which will have only 1 or 2 riders. They’re all fun!</p>
+                <p><strong>Pedalpalooza 2018 starts on the first of June and ends on the 30th - a full month of bike fun!</strong></p>
+
+                <h2>History</h2>
+                <p>The tradition of a summer bike fun festival in Portland started in Summer of 2002, when the nomadic <a href="http://criticalmass.wikia.com/wiki/Bike_Summer!" rel="noopener">BikeSummer festival</a> came to Portland. We had so much fun that we decided we should keep having bike fun festivals and went through a couple of iterations - including <a href="https://www.portlandmercury.com/news/summer-bike-events/Content?oid=29035" rel="noopener">Mini Bike Summer</a> in 2003 before Pedalpalooza was dreamed up in 2004. It’s happened <a href="pedalpaloozaArchive">every year since then</a>, and grown quite a bit!</p>
+
+                <h2>Flagship rides</h2>
+                <ul>
+                    <li><p><strong>The Kickoff Ride</strong>.  The first major ride of pedalpalooza, on day 1 of the festival. It’s been led by a variety of community members over the years.  It’s always family friendly, usually having a slow pace with a route on major city streets. For the past 4 years, it’s also been the main venue for passing out pedalpalooza pennants which folks attach to their bikes for the duration of the festival so you can "follow the flag to fun!"</p></li>
+
+                    <li><p><strong>The local version of The World Naked Bike Ride</strong>.  Usually the largest organized point-to-point bike ride in the state (with a planned route, infrastructure like portapotties and security staff, and around 10,000 participants). See <a href="https://pdxwnbr.org/" rel="noopener">the PDX WNBR website</a> for more details.  The 2018 ride is on June 23rd.</p></li>
+
+                    <li><p><strong>Loud and Lit</strong> - A loud, bright, dance party ride, usually featuring well over 1,000 participants.</p></li>
+
+                    <li><p><strong>Sunday Parkways</strong> - The Portland Bureau of Transportation runs a series of events on Sundays during the summer during which a loop of streets in various neighborhoods is closed to car traffic, so people can walk and bike and use other human-powered transport to enjoy the streets together.  <a href="https://www.portlandoregon.gov/transportation/67622" rel="noopener">This year’s June Sunday Parkways is on June 24th</a> in North Portland.</p></li>
+                </ul>
+
+            </div>
+        </div>
+    </script>
+
     <script id="pedalpaloozaArchive" type="text">
         <div>
             <h1>Pedalpalooza Archive</h1>
 
             <div class="archive">
                 <p class="byline">aka, That Fun Thing We Do Every June</p>
-                <p>In 2002, Portland hosted <a href="http://criticalmass.wikia.com/wiki/Bike_Summer!">Bike Summer</a>, and it was great! So, every summer since then, we've had another festival which is now called <dfn>Pedalpalooza</dfn>. Choose one of the following years to see its calendar of events.</p>
+                <p>In 2002, Portland hosted <a href="http://criticalmass.wikia.com/wiki/Bike_Summer!" rel="noopener">Bike Summer</a>, and it was great! So, every summer since then, we've had another festival which is now called <dfn>Pedalpalooza</dfn>. Choose one of the following years to see its calendar of events.</p>
 
                 <ul class="archive-list">
                     <li>
@@ -315,7 +342,7 @@
                     </li>
                     <li>
                         <!-- former url, http://bikesummer.org/2002/events/index.htm -->
-                        <a class="year btn" href="http://web.archive.org/web/20020428220445/http://www.bikesummer.org/2002/events/index.htm">2002</a>
+                        <a class="year btn" href="http://web.archive.org/web/20020428220445/http://www.bikesummer.org/2002/events/index.htm" rel="noopener">2002</a>
                         <p class="description">BikeSummer!  In August, not June?  Wow, the things we forget. 97 events.</p>
                     </li>
                 </ul>

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -171,6 +171,12 @@ $(document).ready( function() {
         });
     }
 
+    function viewAboutPedalpalooza() {
+        var content = $('#aboutPedalpalooza').html();
+        container.empty().append(content);
+        checkAnchors();
+    }
+
     function viewPedalpaloozaArchive() {
         var content = $('#pedalpaloozaArchive').html();
         container.empty().append(content);
@@ -334,6 +340,7 @@ $(document).ready( function() {
     addRoute(/viewEvents$/, viewEvents);
     addRoute(/aboutUs$/, viewAbout);
     addRoute(/pedalpaloozaArchive$/, viewPedalpaloozaArchive);
+    addRoute(/aboutPedalpalooza$/, viewAboutPedalpalooza);
     addRoute(/event-([0-9]*)$/, function (frag) {
         var rx = /event-([0-9]*)$/g;
         var arr = rx.exec(frag);


### PR DESCRIPTION
Previously this was linking to a page on `docs.shift2bikes.org` which has the same content. That site isn't quite ready for prime time yet, though, and this caused some confusion as people started browsing other pages on that site which are not complete. Until that site is ready to go, this change adds the same content to the Fun cal. 